### PR TITLE
ensure WError toString gets the constructor name properly

### DIFF
--- a/lib/verror.js
+++ b/lib/verror.js
@@ -98,7 +98,7 @@ function WError(options)
 {
 	Error.call(this);
 
-	var args, cause, ctor, name;
+	var args, cause, ctor;
 	if (typeof (options) === 'object') {
 		args = Array.prototype.slice.call(arguments, 1);
 	} else {
@@ -118,23 +118,22 @@ function WError(options)
 		} else {
 			cause = options.cause;
 			ctor = options.constructorOpt;
-			name = options.name;
 		}
 	}
 
 	Error.captureStackTrace(this, ctor || this.constructor);
-	this.name = name || this.constructor.name;
 	if (cause)
 		this.cause(cause);
 
 }
 
 mod_util.inherits(WError, Error);
+WError.prototype.name = 'WError';
 
 
 WError.prototype.toString = function we_toString()
 {
-	var str = this.name;
+	var str = this.constructor.prototype.name;
 	if (this.message)
 		str += ': ' + this.message;
 	if (this.we_cause && this.we_cause.message)


### PR DESCRIPTION
Also drop 'options.name' support to WError ctor, per discussion
with MarkC.

Note: there will be a related PR to restify v2.0 in a sec.
