### PR TITLE
VError and WError toString() use the ctor name, fallback to prototype.name

### DIFF
--- a/lib/verror.js
+++ b/lib/verror.js
@@ -59,6 +59,16 @@ function VError(options)
 mod_util.inherits(VError, Error);
 VError.prototype.name = 'VError';
 
+VError.prototype.toString = function ve_toString()
+{
+	// If ctor is an anon function, then allow setting `.prototype.name`.
+	var str = this.constructor.name || this.constructor.prototype.name;
+	if (this.message)
+		str += ': ' + this.message;
+
+	return (str);
+};
+
 VError.prototype.cause = function ve_cause()
 {
 	return (this.jse_cause);
@@ -128,7 +138,8 @@ WError.prototype.name = 'WError';
 
 WError.prototype.toString = function we_toString()
 {
-	var str = this.constructor.prototype.name;
+	// If ctor is an anon function, then allow setting `.prototype.name`.
+	var str = this.constructor.name || this.constructor.prototype.name;
 	if (this.message)
 		str += ': ' + this.message;
 	if (this.we_cause && this.we_cause.message)

--- a/tests/tst.inherit.js
+++ b/tests/tst.inherit.js
@@ -3,7 +3,7 @@
  */
 
 var mod_assert = require('assert');
-var mod_sys = require('util');
+var mod_util = require('util');
 
 var mod_verror = require('../lib/verror');
 
@@ -16,7 +16,7 @@ function VErrorChild()
 	VError.apply(this, Array.prototype.slice.call(arguments));
 }
 
-mod_sys.inherits(VErrorChild, VError);
+mod_util.inherits(VErrorChild, VError);
 VErrorChild.prototype.name = 'VErrorChild';
 
 
@@ -25,8 +25,8 @@ function WErrorChild()
 	WError.apply(this, Array.prototype.slice.call(arguments));
 }
 
-mod_sys.inherits(WErrorChild, WError);
-VErrorChild.prototype.name = 'WErrorChild';
+mod_util.inherits(WErrorChild, WError);
+WErrorChild.prototype.name = 'WErrorChild';
 
 
 suberr = new Error('root cause');
@@ -36,6 +36,8 @@ mod_assert.ok(err instanceof VError);
 mod_assert.ok(err instanceof VErrorChild);
 mod_assert.equal(err.cause(), suberr);
 mod_assert.equal(err.message, 'top: root cause');
+mod_assert.equal(err.toString(), 'VErrorChild: top: root cause');
+mod_assert.equal(err.stack.split('\n')[0], 'VErrorChild: top: root cause');
 
 suberr = new Error('root cause');
 err = new WErrorChild(suberr, 'top');
@@ -44,3 +46,43 @@ mod_assert.ok(err instanceof WError);
 mod_assert.ok(err instanceof WErrorChild);
 mod_assert.equal(err.cause(), suberr);
 mod_assert.equal(err.message, 'top');
+mod_assert.equal(err.toString(),
+	'WErrorChild: top; caused by Error: root cause');
+mod_assert.equal(err.stack.split('\n')[0],
+	'WErrorChild: top; caused by Error: root cause');
+
+
+// Test that `<Ctor>.toString()` uses the ctor name. I.e. setting
+// `<Ctor>.prototype.name` isn't necessary.
+function VErrorChildNoName() {
+	VError.apply(this, Array.prototype.slice.call(arguments));
+}
+mod_util.inherits(VErrorChildNoName, VError);
+err = new VErrorChildNoName('top');
+mod_assert.equal(err.toString(), 'VErrorChildNoName: top');
+
+function WErrorChildNoName() {
+	WError.apply(this, Array.prototype.slice.call(arguments));
+}
+mod_util.inherits(WErrorChildNoName, WError);
+err = new WErrorChildNoName('top');
+mod_assert.equal(err.toString(), 'WErrorChildNoName: top');
+
+
+// Test that `<Ctor>.prototype.name` can be used for the `.toString()`
+// when the ctor is anonymous.
+var VErrorChildAnon = function () {
+	VError.apply(this, Array.prototype.slice.call(arguments));
+}
+mod_util.inherits(VErrorChildAnon, VError);
+VErrorChildAnon.prototype.name = 'VErrorChildAnon';
+err = new VErrorChildAnon('top');
+mod_assert.equal(err.toString(), 'VErrorChildAnon: top');
+
+var WErrorChildAnon = function () {
+	WError.apply(this, Array.prototype.slice.call(arguments));
+}
+mod_util.inherits(WErrorChildAnon, WError);
+WErrorChildAnon.prototype.name = 'WErrorChildAnon';
+err = new WErrorChildAnon('top');
+mod_assert.equal(err.toString(), 'WErrorChildAnon: top');


### PR DESCRIPTION
With a scenario like this:

```
function ConnectionClosedError() {
        WError.call(this, 'connection closed; request aborted');
}
util.inherits(ConnectionClosedError, WError);
```

recent changes made it so the toString() would use 'WError' as the
error name instead of 'ConnectionClosedError'. One needed to also
do:

```
ConnectionClosedError.prototype.name = 'ConnectionClosedError';
```

Drop the need for that boilerplate.

Note: I've made the `this.constructor.name` win here over `this.constructor.prototype.name`. Ideally I'd have had it the other way around, but that isn't possible because then you'd still need the boilerplate above as the `WError.prototype.name = 'WError'` would "win".
