### PR TITLE
add getFullStack method

### DIFF
--- a/lib/verror.js
+++ b/lib/verror.js
@@ -247,3 +247,12 @@ WError.prototype.cause = function we_cause(c)
 
 	return (this.we_cause);
 };
+
+WError.prototype.getFullStack = function  we_getFullStack(c)
+{
+	if (this.we_cause)
+		return this.stack + '\ncaused by: ' +
+			(this.we_cause instanceof WError ?
+				this.we_cause.getFullStack() : this.we_cause.stack);
+	return this.stack;
+};

--- a/lib/verror.js
+++ b/lib/verror.js
@@ -248,11 +248,11 @@ WError.prototype.cause = function we_cause(c)
 	return (this.we_cause);
 };
 
-WError.prototype.getFullStack = function  we_getFullStack(c)
+WError.prototype.fullStack = function  we_fullStack(c)
 {
 	if (this.we_cause)
 		return this.stack + '\ncaused by: ' +
 			(this.we_cause instanceof WError ?
-				this.we_cause.getFullStack() : this.we_cause.stack);
+				this.we_cause.fullStack() : this.we_cause.stack);
 	return this.stack;
 };

--- a/tests/tst.werror.js
+++ b/tests/tst.werror.js
@@ -177,3 +177,17 @@ mod_assert.equal(stack, [
     'WError: test error',
     '    at Object.<anonymous> (tst.werror.js)'
 ].join('\n') + '\n' + nodestack);
+
+suberr = new WError(new Error('root cause'), 'mid');
+err = new WError(suberr, 'top');
+stack = cleanStack(err.getFullStack());
+mod_assert.equal(stack, [
+    'WError: top; caused by WError: mid; caused by Error: root cause',
+    '    at Object.<anonymous> (tst.werror.js)'
+].join('\n') + '\n' + nodestack + '\n' + [
+    'caused by: WError: mid; caused by Error: root cause',
+    '    at Object.<anonymous> (tst.werror.js)'
+].join('\n') + '\n' + nodestack + '\n' + [
+    'caused by: Error: root cause',
+    '    at Object.<anonymous> (tst.werror.js)'
+].join('\n') + '\n' + nodestack);

--- a/tests/tst.werror.js
+++ b/tests/tst.werror.js
@@ -180,7 +180,7 @@ mod_assert.equal(stack, [
 
 suberr = new WError(new Error('root cause'), 'mid');
 err = new WError(suberr, 'top');
-stack = cleanStack(err.getFullStack());
+stack = cleanStack(err.fullStack());
 mod_assert.equal(stack, [
     'WError: top; caused by WError: mid; caused by Error: root cause',
     '    at Object.<anonymous> (tst.werror.js)'


### PR DESCRIPTION
Happy to make modifications to the method name, or the format of the output.

```
WError: top; caused by WError: mid; caused by Error: root cause
    at Object.<anonymous> (tst.werror.js)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:935:3
caused by: WError: mid; caused by Error: root cause
    at Object.<anonymous> (tst.werror.js)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:935:3
caused by: Error: root cause
    at Object.<anonymous> (tst.werror.js)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:935:3
```