### PR TITLE
Update test results for Node.js 4

### DIFF
--- a/tests/tst.inherit.js
+++ b/tests/tst.inherit.js
@@ -47,7 +47,7 @@ mod_assert.equal(err.message, 'top');
 mod_assert.equal(err.toString(),
 	'WErrorChild: top; caused by Error: root cause');
 mod_assert.equal(err.stack.split('\n')[0],
-	'WErrorChild: top; caused by Error: root cause');
+	'WErrorChild: top');
 
 
 // Test that `<Ctor>.toString()` uses the ctor name. I.e. setting

--- a/tests/tst.serror.js
+++ b/tests/tst.serror.js
@@ -32,7 +32,7 @@ mod_assert.equal(err.message, '');
 mod_assert.ok(err.cause() === undefined);
 stack = cleanStack(err.stack);
 mod_assert.equal(stack, [
-    'SError',
+    'VError',
     '    at Object.<anonymous> (tst.serror.js)'
 ].join('\n') + '\n' + nodestack);
 
@@ -55,7 +55,7 @@ mod_assert.equal(err.message, 'something wrong?: hello 3 worlds');
 mod_assert.ok(err.cause() === suberr);
 stack = cleanStack(err.stack);
 mod_assert.equal(stack, [
-    'SError: something wrong?: hello 3 worlds'
+    'VError: something wrong?: hello 3 worlds'
 ].join('\n') + '\n' + nodestack);
 
 /* bad arguments */

--- a/tests/tst.werror.js
+++ b/tests/tst.werror.js
@@ -94,7 +94,7 @@ mod_assert.equal(err.toString(), 'WError: proximate cause: 3 issues; ' +
 mod_assert.ok(err.cause() === suberr);
 stack = cleanStack(err.stack);
 mod_assert.equal(stack, [
-    'WError: proximate cause: 3 issues; caused by Error: root cause',
+    'WError: proximate cause: 3 issues',
     '    at Object.<anonymous> (tst.werror.js)'
 ].join('\n') + '\n' + nodestack);
 
@@ -105,7 +105,7 @@ mod_assert.equal(err.toString(), 'WError: proximate cause: 3 issues; ' +
 mod_assert.ok(err.cause() === suberr);
 stack = cleanStack(err.stack);
 mod_assert.equal(stack, [
-    'WError: proximate cause: 3 issues; caused by Error: root cause',
+    'WError: proximate cause: 3 issues',
     '    at Object.<anonymous> (tst.werror.js)'
 ].join('\n') + '\n' + nodestack);
 


### PR DESCRIPTION
Note that I don't suggest you merge this as is - it is merely to demonstrate the differences that occur in stack traces when using Node.js 4 to run the tests.

The basic problem is that as a result of https://codereview.chromium.org/21761002 any custom `toString` method on a subclass of Error is not honoured when building the first line of the stack trace, so a `WError` does not get the cause added, and an `SError` is reported as a `VError`.

Obviously any real fix would either need to allow either result, or would need to find another way to get the expected stack traces.