### PR TITLE
Do not call sprintf with zero argument

### DIFF
--- a/lib/verror.js
+++ b/lib/verror.js
@@ -114,8 +114,13 @@ function parseConstructorArguments(args)
 		});
 	}
 
+	/**
+	 * Do not call sprintf with one argument, performance optimization
+	 */
 	if (sprintf_args.length === 0) {
 		shortmessage = '';
+	} else if (sprintf_args.length === 1) {
+		shortmessage = sprintf_args[0];
 	} else {
 		shortmessage = sprintf.apply(null, sprintf_args);
 	}


### PR DESCRIPTION
Calling `sprintf` is expensive, do not call when zero arguments are passed.
In some scenarios, an application needs to create hundreds of VError(s).

To test the change's effect:

```
for(var i = 0; i < 10000; i++) {
        new mod_verror.VError('Foo')
}
```

On my 2017 MBP 3.5Ghz, I see a 27% performance improvement after the change.

Before:
![screen shot 2018-12-31 at 10 29 47 am](https://user-images.githubusercontent.com/1764512/50565766-07d6b100-0ce7-11e9-9e6e-fcbd6cc5d7dd.png)
