### PR TITLE
node-verror#83 Syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
 		"core-util-is": "1.0.2",
 		"extsprintf": "^1.2.0"
 	},
-	"engines": [
-		"node >=0.6.0"
-	],
+	"engines": {
+		"node": ">=0.6.0"
+	},
 	"scripts": {
 		"test": "make test"
 	},


### PR DESCRIPTION
My Linter (With default settings) was complaining. I don't think this brakes anything. If this library is actually about verbose errors in `js`. I think we should keep up with the times.

Also I got an actual error on this, when using [jq](https://stedolan.github.io/jq/) in a query, making checks on my dependencies.
