### PR TITLE
use caret range specifier for core-util-is

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"assert-plus": "^1.0.0",
-		"core-util-is": "1.0.2",
+		"core-util-is": "^1.0.2",
 		"extsprintf": "^1.2.0"
 	},
 	"engines": {


### PR DESCRIPTION
doesn't change anything really, all tests still pass
I saw I had two versions of core-util-is in my node_modules and noticed the package was specified exactly here